### PR TITLE
Remove phpdoc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 # Change Log
 
 
+## Unreleased
+
+### Removed
+
+- Phpdoc (not really required since PHP 7)
+
+
 ## 0.0.2 - 2017-04-20
 
 ### Added

--- a/src/ErrorHandler.php
+++ b/src/ErrorHandler.php
@@ -17,9 +17,6 @@ interface ErrorHandler
      * The above parameters follow common sense and it SHOULD be possible to fit them into any workflow.
      *
      * @see Context
-     *
-     * @param \Throwable $t
-     * @param array      $context
      */
     public function handle(\Throwable $t, array $context = []): void;
 }

--- a/src/ErrorHandlerAware.php
+++ b/src/ErrorHandlerAware.php
@@ -11,8 +11,6 @@ interface ErrorHandlerAware
 {
     /**
      * Sets an error handler instance.
-     *
-     * @param ErrorHandler $errorHandler
      */
     public function setErrorHandler(ErrorHandler $errorHandler): void;
 }

--- a/src/HasErrorHandler.php
+++ b/src/HasErrorHandler.php
@@ -16,8 +16,6 @@ trait HasErrorHandler
 
     /**
      * Sets an error handler instance.
-     *
-     * @param ErrorHandler $errorHandler
      */
     public function setErrorHandler(ErrorHandler $errorHandler): void
     {


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| License         | MIT


#### What's in this PR?

Removal of phpdoc.


#### Why?

With PHP 7 we don't really need that anymore
