### PR TITLE
Add PSR-3 Log error handler implementation, closes #4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 
 ## Unreleased
 
+### Added
+
+- PSR-3 Log error handler
+
 ### Removed
 
 - Phpdoc (not really required since PHP 7)

--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,7 @@ clean: ## Clean the working area
 	rm -rf build/ vendor/
 
 test: ## Run tests
+	@vendor/bin/phpunit
 
 docker: ## Execute commands inside a Docker container
 	docker run --rm -it -v $$PWD:/app -w /app $(DOCKER_IMAGE) make $(filter-out docker, $(MAKECMDGOALS))

--- a/composer.json
+++ b/composer.json
@@ -13,6 +13,10 @@
     "require": {
         "php": "^7.1"
     },
+    "require-dev": {
+        "phpunit/phpunit": "^6.1",
+        "psr/log": "^1.0"
+    },
     "autoload": {
         "psr-4": {
             "Nofw\\Error\\": "src/"

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit colors="true" bootstrap="vendor/autoload.php">
+    <testsuites>
+        <testsuite name="Emperror Test Suite">
+            <directory>tests/</directory>
+        </testsuite>
+    </testsuites>
+    <filter>
+        <whitelist>
+            <directory suffix=".php">src/</directory>
+        </whitelist>
+    </filter>
+</phpunit>

--- a/src/Psr3ErrorHandler.php
+++ b/src/Psr3ErrorHandler.php
@@ -1,0 +1,73 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nofw\Error;
+
+use Psr\Log\LoggerAwareInterface;
+use Psr\Log\LoggerAwareTrait;
+use Psr\Log\LogLevel;
+use Psr\Log\NullLogger;
+
+/**
+ * This handler can be used to log errors using a PSR-3 logger.
+ *
+ * @author Márk Sági-Kazár <mark.sagikazar@gmail.com>
+ */
+final class Psr3ErrorHandler implements ErrorHandler, LoggerAwareInterface
+{
+    use LoggerAwareTrait;
+
+    /**
+     * The log level to be used.
+     *
+     * @var string
+     */
+    private $level;
+
+    /**
+     * Attach the error to the context or not.
+     *
+     * @var bool
+     */
+    private $attachError;
+
+    public function __construct(string $level = LogLevel::CRITICAL, bool $attachError = true)
+    {
+        $this->level = $level;
+        $this->attachError = $attachError;
+        $this->logger = new NullLogger();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function handle(\Throwable $t, array $context = []): void
+    {
+        if ($this->attachError) {
+            $context['throwable'] = $t;
+        }
+
+        // Determine the error type
+        if ($t instanceof \Exception) {
+            $type = 'Exception';
+        } elseif ($t instanceof \Error) {
+            $type = 'Error';
+        } else {
+            $type = 'Throwable';
+        }
+
+        $this->logger->log(
+            $this->level,
+            sprintf(
+                '%s \'%s\' with message \'%s\' in %s(%s)',
+                $type,
+                get_class($t),
+                $t->getMessage(),
+                $t->getFile(),
+                $t->getLine()
+            ),
+            $context
+        );
+    }
+}

--- a/tests/Psr3ErrorHandlerTest.php
+++ b/tests/Psr3ErrorHandlerTest.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace Nofw\Error\Tests;
+
+use Nofw\Error\Psr3ErrorHandler;
+use PHPUnit\Framework\TestCase;
+use Prophecy\Argument;
+use Prophecy\Prophecy\ObjectProphecy;
+use Psr\Log\LoggerInterface;
+use Psr\Log\LogLevel;
+
+final class Psr3ErrorHandlerTest extends TestCase
+{
+    /**
+     * @test
+     */
+    public function it_logs_at_critical_level_and_attaches_the_error_to_the_context_by_default()
+    {
+        /** @var LoggerInterface|ObjectProphecy $logger */
+        $logger = $this->prophesize(LoggerInterface::class);
+
+        $errorHandler = new Psr3ErrorHandler();
+        $errorHandler->setLogger($logger->reveal());
+
+        $exception = new \Exception();
+
+        $logger->log(LogLevel::CRITICAL, Argument::type('string'), ['throwable' => $exception])->shouldBeCalled();
+
+        $errorHandler->handle($exception);
+    }
+
+    /**
+     * @test
+     */
+    public function it_accepts_a_log_level()
+    {
+        /** @var LoggerInterface|ObjectProphecy $logger */
+        $logger = $this->prophesize(LoggerInterface::class);
+
+        $errorHandler = new Psr3ErrorHandler(LogLevel::ERROR);
+        $errorHandler->setLogger($logger->reveal());
+
+        $exception = new \Exception();
+
+        $logger->log(LogLevel::ERROR, Argument::type('string'), ['throwable' => $exception])->shouldBeCalled();
+
+        $errorHandler->handle($exception);
+    }
+
+    /**
+     * @test
+     */
+    public function it_allows_to_disable_attaching_the_error()
+    {
+        /** @var LoggerInterface|ObjectProphecy $logger */
+        $logger = $this->prophesize(LoggerInterface::class);
+
+        $errorHandler = new Psr3ErrorHandler(LogLevel::CRITICAL, false);
+        $errorHandler->setLogger($logger->reveal());
+
+        $exception = new \Exception();
+
+        $logger->log(LogLevel::CRITICAL, Argument::type('string'), [])->shouldBeCalled();
+
+        $errorHandler->handle($exception);
+    }
+}


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | fixes #4
| License         | MIT


#### What's in this PR?

Add PSR-3 error handler.


#### Why?

PSR-3 is already a standard


#### Example Usage

``` php
use Nofw\Error\Psr3ErrorHandler;
use Monolog\Logger;

$errorHandler = new Psr3ErrorHandler();

$errorHandler->setLogger(new Logger('error'));
```


#### Checklist

- [x] Updated CHANGELOG.md to describe BC breaks / deprecations | new feature | bugfix

